### PR TITLE
Use libxml2 module from runtime

### DIFF
--- a/org.cznic.Datovka.yaml
+++ b/org.cznic.Datovka.yaml
@@ -15,14 +15,15 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Notifications
 
+cleanup:
+  - "*.a"
+  - "*.la"
+  - "*.cmake"
+  - "*.pc"
+  - "/bin/xml*"
+  - /include
+
 modules:
-  - name: libxml2
-    config-opts:
-        - --without-python
-    sources:
-        - type: archive
-          url: https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.1.tar.xz
-          sha256: c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c
 
   - name: libgcrypt-config
     buildsystem: simple
@@ -67,13 +68,7 @@ modules:
           dest-filename: datovka-script
           commands: 
             - exec env TMPDIR=$XDG_CACHE_HOME /app/bin/datovka-run "$@"  
-cleanup:
-  - "*.a"
-  - "*.la"
-  - "*.cmake"
-  - "*.pc"
-  - "/bin/xml*"
-  - /include
+
   - /share/aclocal
   - "/share/doc/libxml*"
   - /share/gtk-doc

--- a/org.cznic.Datovka.yaml
+++ b/org.cznic.Datovka.yaml
@@ -22,6 +22,10 @@ cleanup:
   - "*.pc"
   - "/bin/xml*"
   - /include
+  - /share/aclocal
+  - "/share/doc/libxml*"
+  - /share/gtk-doc
+  - /share/man
 
 modules:
 
@@ -68,8 +72,3 @@ modules:
           dest-filename: datovka-script
           commands: 
             - exec env TMPDIR=$XDG_CACHE_HOME /app/bin/datovka-run "$@"  
-
-  - /share/aclocal
-  - "/share/doc/libxml*"
-  - /share/gtk-doc
-  - /share/man


### PR DESCRIPTION
KDE runtime version 6.10 (based on the Freedesktop runtime version 25.08) appears to provide the **libxml2** module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/libxml2.bst

Fixes: https://github.com/flathub/org.cznic.Datovka/issues/21